### PR TITLE
ENH: converted data class to double explicitly

### DIFF
--- a/source_code/Tmo/RamanTMO.m
+++ b/source_code/Tmo/RamanTMO.m
@@ -57,6 +57,9 @@ end
 
 C = 70.0 / 255.0; %As reported in Raman and Chaudhuri Eurographics 2009 short paper
 
+%make sure data must be of class "double"
+imageStack = im2double(imageStack);
+
 %number of images in the imageStack
 [r, c, col, n] = size(imageStack);
 


### PR DESCRIPTION
With this commit, the script `demo_fusion_from_stack` stops report the `data must be of class double` error, which is thrown from `bilateralFilter`. And the computation can be successfully conducted. 

P.S.: All the computation were conducted on a PC with Windows 7 64bit, the Matlab version is 2012b.

