### PR TITLE
Fix reference for Krawczyk TMO

### DIFF
--- a/source_code/Tmo/KrawczykTMO.m
+++ b/source_code/Tmo/KrawczykTMO.m
@@ -26,7 +26,7 @@ function imgOut = KrawczykTMO(img)
 %     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %
 %     The paper describing this technique is:
-%     "A Model of Visual Adaptation for Realistic Image Synthesis"
+%     "Lightness Perception in Tone Reproduction for High Dynamic Range Images"
 % 	  by Grzegorz Krawczyk, Karol Myszkowski, Hans-Peter Seidel
 %     in Proceedings of EUROGRAPHICS 2005
 %


### PR DESCRIPTION
This PR fixes misleading reference in `KrawczykTMO.m' (it should be "Lightness Perception in Tone Reproduction for High Dynamic Range Images", not "A Model of Visual Adaptation for Realistic Image Synthesis")