### PR TITLE
Use updated centroids from KrawczykImagePartition

### DIFF
--- a/source_code/Tmo/KrawczykTMO.m
+++ b/source_code/Tmo/KrawczykTMO.m
@@ -47,7 +47,7 @@ LLog10 = log10(L + 1e-6);
 [C, totPixels] = KrawczykKMeans(bound, histo);
 
 %partition the image into frameworks
-[framework, distance] = KrawczykImagePartition(C, LLog10, bound, totPixels);
+[framework, distance, C] = KrawczykImagePartition(C, LLog10, bound, totPixels);
 
 %compute P_i
 sigma = KrawczykMaxDistance(C, bound);

--- a/source_code/Tmo/util/KrawczykImagePartition.m
+++ b/source_code/Tmo/util/KrawczykImagePartition.m
@@ -1,4 +1,4 @@
-function [framework, distance] = KrawczykImagePartition(C, LLog10, bound, totPixels)
+function [framework, distance, C] = KrawczykImagePartition(C, LLog10, bound, totPixels)
 %
 %
 %       [framework, distance] = KrawczykImagePartition(C, LLog10, bound, totPixels)


### PR DESCRIPTION
KrawczykImagePartition can remove and/or modify centroid locations. Without this change, the centroids used in KrawczykImagePartition for computing the probability maps don't match well with their respective framework pixel values.

Recreated this PR for develop branch